### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Yann Miecielica
 maintainer=Yann Miecielica
 sentence=An Arduino library for managing all common sensors with shared interfaces
 paragraph=
-category=Sensor
+category=Sensors
 url=https://github.com/yMiecie/
 architectures=*


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category 'Sensor' in library Sensors is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format